### PR TITLE
Fix crash when restoring tab selection

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -197,6 +197,8 @@ extension TabManager {
             addTab(request: NSURLRequest(URL: url))
         }
         let selectedIndex: Int = coder.decodeIntegerForKey("selectedIndex")
-        self.selectTab(tabs[selectedIndex])
+        if (selectedIndex >= 0) {
+            self.selectTab(tabs[selectedIndex])
+        }
     }
 }


### PR DESCRIPTION
When selectedIndex was -1 (= no tab selected) self.selectTab(tabs[selectedIndex]) would crash